### PR TITLE
:wrench: (renovate): Improve Renovate configuration

### DIFF
--- a/.renovaterc.json
+++ b/.renovaterc.json
@@ -1,6 +1,7 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
+    ":automergeStableNonMajor",
     ":dependencyDashboardApproval",
     "config:best-practices",
     "regexManagers:dockerfileVersions",
@@ -26,13 +27,16 @@
         "major",
         "minor",
         "patch",
-        "pin",
         "digest",
         "bump",
         "replacement"
       ],
       "semanticCommitType": ["⬆️"],
       "semanticCommitScope": "dependencies"
+    },
+    {
+      "matchPackagePrefixes": ["oci.chezmoi.sh/"],
+      "allowedVersions": ""
     }
   ],
   "semanticCommits": "enabled",

--- a/apps/images/alpine/authelia/Dockerfile
+++ b/apps/images/alpine/authelia/Dockerfile
@@ -47,9 +47,9 @@ RUN set -eux; \
 # └───────────────────────────────────────────────────────────────────────────┘
 FROM --platform=arm64 docker.io/library/golang:1.21.5-alpine3.19 as builder-backend
 
-# renovate: datasource=repology depName=alpine_3_19/gcc versioning=semver
+# renovate: datasource=repology depName=alpine_3_19/gcc versioning=loose
 ARG GCC_VERSION=13.2.1_git20231014-r0
-# renovate: datasource=repology depName=alpine_3_19/musl-dev versioning=semver
+# renovate: datasource=repology depName=alpine_3_19/musl-dev versioning=loose
 ARG MUSL_DEV_VERSION=1.2.4_git20230717-r4
 
 # trunk-ignore(hadolint/DL3018): don't care to pin dependencies on build


### PR DESCRIPTION
Avoid finding deps for oci.chezmoi.sh images and use versionning=loose
for all Alpine PKG
